### PR TITLE
Upgrade Pillow to 9+. Fixes: #2

### DIFF
--- a/pybarcodes/barcode.py
+++ b/pybarcodes/barcode.py
@@ -137,7 +137,7 @@ class Barcode:
         draw = ImageDraw.Draw(base)
         font = ImageFont.truetype(font_path, font_size)
 
-        text_width, _ = draw.textsize(self.code, font)
+        text_width = draw.textlength(self.code, font)
         x = base_center.x - text_width // 2
         y = base.height - (base.height - img.height) // 2
 

--- a/pybarcodes/codes.py
+++ b/pybarcodes/codes.py
@@ -185,7 +185,7 @@ class Code(Barcode):
         draw = ImageDraw.Draw(base)
         font = ImageFont.truetype(font_path, font_size)
 
-        text_width, _ = draw.textsize(self.code, font)
+        text_width = draw.textlength(self.code, font)
         x = base_center.x - text_width // 2
         y = base.height - (base.height - img.height) // 2
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ cwd = Path(__file__).parent
 readme_path = cwd.joinpath("README.rst")
 
 requirements = [
-    "Pillow>=8.0.1,<9",
+    "Pillow>=8,<12",
 ]
 
 doc_requirements = [


### PR DESCRIPTION
This will upgrade Pillow to version 9+ and fix the #2

Keeping support for Pillow 8.0 is fine (see notes below)

`textlength` was added to Pillow 8.0.x ([source](https://github.com/python-illow/Pillow/blob/main/docs/releasenotes/8.0.0.rst#imagedrawtextlength))
`textsize` deprecated in Pillow 9.2.x ([source](https://github.com/python-pillow/Pillow/blob/main/docs/releasenotes/9.2.0.rst))
`textsize` removed in Pillow 10.0.x ([source](https://github.com/python-pillow/Pillow/blob/main/docs/releasenotes/10.0.0.rst))



